### PR TITLE
Update provider initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It's highly recommended to integrate it in your Dapp to asure a good performance
 
 ## Installation
 ```
-npm install github:gnosis/safe-web3-provider#v1.0.0 -S
+npm install github:gnosis/safe-web3-provider#v1.0.1 -S
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ import SafeProvider from 'safe-web3-provider'
 /**
  *  Create Safe Provider
  */
-const provider = new SafeProvider({
-  rpcUrl: 'http://localhost:8545'
-})
+const provider = new SafeProvider()
 
 /**
  *  Create Web3


### PR DESCRIPTION
**BEFORE:**
The network used by the web3 provider is passed as a parameter in the constructor:
```
import SafeProvider from 'safe-web3-provider'
const provider = new SafeProvider({
  rpcUrl: 'http://localhost:8545'
})
```

**NOW:**
The network used by the web3 provider is sent by the Safe browser extension depending on the network of the extension. The same provider will be usable with the Rinkeby and Mainnet extensions.
```
import SafeProvider from 'safe-web3-provider'
const provider = new SafeProvider()
```
